### PR TITLE
Changed select option in FBI search to Rails version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/views/ajax/fbi.html.erb
+++ b/app/views/ajax/fbi.html.erb
@@ -9,7 +9,7 @@
     <%= label='Choose a Search Option :' %>
     <%= select_tag(:fbi_api_word, options_for_select([['all'], ['title'], ['description'], 
                                                       ['details'], ['sex'], ['race'],
-                                                      ['id'], ['hair color'], ['hair color'], 
+                                                      ['id'], ['hair color'], 
                                                       ['weight'], ['classification'], ['url']]))%>
   </div>
 

--- a/app/views/ajax/fbi.html.erb
+++ b/app/views/ajax/fbi.html.erb
@@ -3,12 +3,15 @@
 
 <br>
 <br>
-<b>
 <div id='crud_operations_div'>
 
-  <label>Valid Options:  all, title, description, details, sex, race, id, hair color, weight, classification, url</label></b>
-  <input id="fbi_api_word">
-
+  <div class="field">
+    <%= label='Choose a Search Option :' %>
+    <%= select_tag(:fbi_api_word, options_for_select([['all'], ['title'], ['description'], 
+                                                      ['details'], ['sex'], ['race'],
+                                                      ['id'], ['hair color'], ['hair color'], 
+                                                      ['weight'], ['classification'], ['url']]))%>
+  </div>
 
   <button id="fbi_api_button" type="button">Return results</button><br>
 


### PR DESCRIPTION
<!-- Link to issue on project board -->

Issue Link: [Changed select option in FBI search to Rails version #16](https://github.com/jimenezmiguela/Help_Find/issues/16)

## Description
Instead of JS version of selection option for FBI search I used Rails version
<%= label='Choose a Search Option :' %> <%= select_tag(:fbi_api_word, options_for_select([['all'], ['title'], ['description'], ['details'], ['sex'], ['race'], ['id'], ['hair color'], ['hair color'], ['weight'], ['classification'], ['url']]))%>
![image](https://user-images.githubusercontent.com/63619892/160740691-85e628c3-2a9a-46cc-bdc4-6aae26e2c3d5.png)

## Type of Change:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Maintenance or Refactor (non-breaking change which does not affect existing functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I tested my changes locally
- [ ] I added tests to cover new functionality
- [ ] All new and existing tests are passing (`bundle exec rspec`)
- [ ] I updated my branch with master so that they can be merged easily