### PR TITLE
Fixed storing record by row number on FBI page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
@@ -228,4 +229,4 @@ RUBY VERSION
    ruby 3.0.1p64
 
 BUNDLED WITH
-   2.2.33
+   2.3.8

--- a/app/javascript/packs/fbi_operations.js
+++ b/app/javascript/packs/fbi_operations.js
@@ -31,13 +31,18 @@ function handle_fbi_ajax(event)
           console.log(fbiApiResponseData);
           var fbiEntry = fbiApiWord.value
           var counter = 1
+          var index = 0
           var i = parseInt(fbiEntry) - 1
           let text = "<table>"
           var fbiMenuWord = fbiMenu.value
+          const fbiApiResponseArray = []
           for (let x in fbiApiResponseData.items)
           for (let s in fbiApiResponseData.items[x].subjects)
           if (fbiApiResponseData.items[x].subjects[s] === 'Kidnappings and Missing Persons' ||   fbiApiResponseData.items[x].subjects[s] === 'ViCAP Missing Persons' )
           {
+            fbiApiResponseArray[index] = fbiApiResponseData.items[x]
+            ++index
+            
             if (fbiEntry || fbiMenuWord === 'all')
             {
               text += "<tr>";
@@ -62,7 +67,9 @@ function handle_fbi_ajax(event)
               text += "<td>" +
               fbiApiResponseData.items[x].url + "</td>";
               text += "<td>" +
-              fbiApiResponseData.items[x].person_classification + "</td></tr>";
+              fbiApiResponseData.items[x].person_classification + "</td>";
+              text += "<td>" +
+              fbiApiResponseData.items[x].subjects[s] + "</td></tr>";
             }
             else if (fbiEntry || fbiMenuWord === 'title')
             {
@@ -187,35 +194,35 @@ function handle_fbi_ajax(event)
             text += "<td>" +
             fbiEntry + "</td>";
             text += "<td>" +
-            fbiApiResponseData.items[i].title + "</td>";
+            fbiApiResponseArray[i].title + "</td>";
             text += "<td>" +
-            fbiApiResponseData.items[i].description + "</td>";
+            fbiApiResponseArray[i].description + "</td>";
             text += "<td>" +
-            fbiApiResponseData.items[i].details + "</td>";
+            fbiApiResponseArray[i].details + "</td>";
             text += "<td>" +
-            fbiApiResponseData.items[i].sex + "</td>";
+            fbiApiResponseArray[i].sex + "</td>";
             text += "<td>" +
-            fbiApiResponseData.items[i].race_raw + "</td>";
+            fbiApiResponseArray[i].race_raw + "</td>";
             text += "<td>" +
-            fbiApiResponseData.items[i].uid + "</td>";
+            fbiApiResponseArray[i].uid + "</td>";
             text += "<td>" +
-            fbiApiResponseData.items[i].hair_raw + "</td>";
+            fbiApiResponseArray[i].hair_raw + "</td>";
             text += "<td>" +
-            fbiApiResponseData.items[i].weight + "</td>";
+            fbiApiResponseArray[i].weight + "</td>";
             text += "<td>" +
-            fbiApiResponseData.items[i].url + "</td>";
+            fbiApiResponseArray[i].url + "</td>";
             text += "<td>" +
-            fbiApiResponseData.items[i].person_classification + "</td></tr>";
+            fbiApiResponseArray[i].person_classification + "</td></tr>";
             // create missing person
             var createMissingPersonData =
             {
               missing_person:
               {
-                name: fbiApiResponseData.items[i].title,
-                sex: fbiApiResponseData.items[i].sex,
-                race: fbiApiResponseData.items[i].race_raw,
-                hair_color: fbiApiResponseData.items[i].hair_raw,
-                weight: fbiApiResponseData.items[i].weight
+                name: fbiApiResponseArray[i].title,
+                sex: fbiApiResponseArray[i].sex,
+                race: fbiApiResponseArray[i].race_raw,
+                hair_color: fbiApiResponseArray[i].hair_raw,
+                weight: fbiApiResponseArray[i].weight
               }
             }
             // HTTP Call
@@ -308,10 +315,10 @@ function handle_fbi_ajax(event)
                     {
                       status_report:
                       {
-                        case_id: fbiApiResponseData.items[i].uid,
-                        description: fbiApiResponseData.items[i].description,
-                        details: fbiApiResponseData.items[i].details,
-                        image_url: fbiApiResponseData.items[i].url
+                        case_id: fbiApiResponseArray.items[i].uid,
+                        description: fbiApiResponseArray.items[i].description,
+                        details: fbiApiResponseArray.items[i].details,
+                        image_url: fbiApiResponseArray.items[i].url
                       }
                     }
                     var fbiCreateIdMissingPersonStatusReport = listMissingPeopleData[(listMissingPeopleData.length)-1].id


### PR DESCRIPTION
<!-- Link to issue on project board -->

Issue Link: [Issue with storing record from FBI to Missing people table](https://github.com/jimenezmiguela/Help_Find/issues/49)

## Description
<!-- When user put row number of the record to the field for storing data in the Missing people table, the record number from FBI request stored in the table instead of chosen record. The separate array was added to get all records after selection of only kidnapped or missing people. -->
<!-- ![image](https://user-images.githubusercontent.com/63619892/164344052-d312015c-e037-432c-8169-933b657c7bb9.png)
![image](https://user-images.githubusercontent.com/63619892/164344172-65e518c2-91c5-418d-9376-e3180bb92faa.png)
![image](https://user-images.githubusercontent.com/63619892/164344266-63700415-f5b9-4085-97fa-828c759aabc5.png)

 -->

## Type of Change:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Maintenance or Refactor (non-breaking change which does not affect existing functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I tested my changes locally
- [ ] I added tests to cover new functionality
- [ ] All new and existing tests are passing (`bundle exec rspec`)
- [x] I updated my branch with master so that they can be merged easily
